### PR TITLE
fix a build error, `/usr/bin/ld: cannot find -ledlib`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -45,6 +45,7 @@ fn main() {
     libdir.push_str(out_path.to_str().unwrap());
     libdir.push_str("/lib");
     println!("{}",libdir);
+    println!("{}64",libdir);
     println!("cargo:rustc-link-lib=edlib");
     println!("{}", lib_std);
 


### PR DESCRIPTION
I can't build `edlib-rs` successfully due to this error:
```
note: /usr/bin/ld: cannot find -ledlib
  collect2: error: ld returned 1 exit status
```
After checking the `edlib-c` build directory:
```
bindings.rs
build
include
lib64
wrapper.h
```
there is no `lib` directory (I don't know why), but there is a directory `lib64`, so I added this line `println!("{}64",libdir);` to `build.rs` and it fixed this error.
